### PR TITLE
Ignore composer self-update failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 before_script:
-  - composer self-update
+  - composer self-update || true
   - composer install --no-interaction
 
 script:


### PR DESCRIPTION
Made composer self-update optional, because a failure here would stop the build.
This command is dependent from the uptime of "getcomposer.org" and only needed if the travis composer version is too old.
