### PR TITLE
PHP 7.0: invalid numeric literal error due to invalid octal number

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitignore       export-ignore
+/.gitattributes   export-ignore
+/.travis.yml      export-ignore
+/docs             export-ignore
+/tests            export-ignore
+/phpdoc.dist.xml  export-ignore
+/phpunit.xml.dist export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ before_script:
   - composer self-update || true
   - composer install --no-interaction
 
-script:
-  - phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
+
+after_script: php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_script:
 
 script:
   - phpunit --coverage-text
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ before_script:
 
 script:
   - phpunit --coverage-text
-  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Moontoast Math Library
 
-[![Build Status](https://travis-ci.org/moontoast/math.png)](https://travis-ci.org/moontoast/math)
+[![Build Status](https://travis-ci.org/ramsey/math.png)](https://travis-ci.org/ramsey/math)
 
 Moontoast\Math is useful for working with integers that are larger than
 (or may become larger than, through mathematical computations) PHP's max

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,10 @@
     "description": "A mathematics library, providing functionality for large numbers",
     "type": "library",
     "keywords": ["math", "bcmath"],
-    "homepage": "https://github.com/moontoast/math",
     "license": "Apache-2.0",
     "support": {
-        "issues": "https://github.com/moontoast/math/issues",
-        "source": "https://github.com/moontoast/math"
+        "issues": "https://github.com/ramsey/moontoast-math/issues",
+        "source": "https://github.com/ramsey/moontoast-math"
     },
     "require": {
         "php": ">=5.3.3",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
         "php": ">=5.3.3",
         "ext-bcmath": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.1"
+    },
     "autoload": {
-        "psr-0": {"Moontoast\\Math": "src/"}
+        "psr-4": {"Moontoast\\Math\\": "src/Moontoast/Math/"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.1",
+        "satooshi/php-coveralls": "~0.6"
     },
     "autoload": {
         "psr-4": {"Moontoast\\Math\\": "src/Moontoast/Math/"}

--- a/tests/Moontoast/Math/BigNumberTest.php
+++ b/tests/Moontoast/Math/BigNumberTest.php
@@ -619,7 +619,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     {
         $fromBase = array(2, 8, 10, 16, 36);
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($toBase as $to) {
@@ -643,7 +643,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -685,7 +685,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10NegativeNumbers()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(-10, -27, -39, -039, -0x5F, '-10', '-27', '-39');
+        $convertValues = array(-10, -27, -39, -037, -0x5F, '-10', '-27', '-39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -707,7 +707,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertToBase10()
     {
         $fromBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($convertValues as $val) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 error_reporting(E_ALL | E_STRICT);
+date_default_timezone_set('UTC');
 
 // Ensure that composer has installed all dependencies
 if (!file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . '/vendor/autoload.php')) {


### PR DESCRIPTION
When you try to run `composer install` on a PHP 7.0.0 (stable) machine, you will get an error along the lines of

```
Parse error: Invalid numeric literal in /home/vagrant/git/math/tests/Moontoast/Math/BigNumberTest.php on line 622
```

Having a look at line 622, you'll see this:

``` php
$convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
```

and using Google for above error you immediately find [PHP bug #70193](https://bugs.php.net/bug.php?id=70193) and there's this explanation:

> Numbers starting with 0 are octal literals. 08 is not a valid octal literal, so you get an error now. Previously it was silently treated like 0.

which really makes sense.

Obviously, the problem is the "octal" (as interpreted by PHP) value `039` which is in fact not octal (`9` isn't a valid octal digit). I changed `039` and `-039` to `037` and `-037`, respectively, and now there are now more syntax errors and the [tests pass](https://travis-ci.org/limenet/math).

I hope you didn't choose `039` because it _might_ produce an unexpected result when converting bases and changing it to `037` doesn't somehow make it "easier" to pass the tests.

What do you think?

(_Note: the "bump" commit was to trigger Travis CI_)
